### PR TITLE
Add missing lock_your_updates property

### DIFF
--- a/admin/class-lock-your-updates-admin.php
+++ b/admin/class-lock-your-updates-admin.php
@@ -17,10 +17,18 @@
 class Lock_Your_Updates_Admin {
 
 	/**
+	 * Instance of Lock_Your_Updates.
+	 *
+	 * @since 1.0
+	 * @var Lock_Your_Updates|null
+	 */
+	protected static $lock_your_updates = null;
+
+	/**
 	 * Instance of this class.
 	 *
 	 * @since 1.0
-	 * @var object
+	 * @var self|null
 	 */
 	protected static $instance = null;
 	


### PR DESCRIPTION
Discovered by @phpstan
If you with to get closer to robust code this is the config.
`phpstan.neon.dist`

```yaml
#$ composer require --dev szepeviktor/phpstan-wordpress phpstan/phpstan-shim
#$ vendor/bin/phpstan analyse --level=2

includes:
    - phar://phpstan.phar/conf/bleedingEdge.neon
    - vendor/szepeviktor/phpstan-wordpress/extension.neon
parameters:
    level: max
    inferPrivatePropertyTypeFromConstructor: true
    paths:
        - %currentWorkingDirectory%/lock-your-updates.php
        - %currentWorkingDirectory%/public/
        - %currentWorkingDirectory%/admin/
    autoload_files:
        - %currentWorkingDirectory%/public/class-lock-your-updates.php
        - %currentWorkingDirectory%/admin/class-lock-your-updates-admin.php
    ignoreErrors:
        # Uses func_get_args()
        - '#^Function apply_filters(_ref_array)? invoked with [34567] parameters, 2 required\.$#'
```